### PR TITLE
Fixed comma issue in displaying drivers

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,9 +27,9 @@ function getRaceTemplate(raceData) {
   return `
     <div>
       <div>Race Name: ${raceData.raceName}</div> 
-      <ul class="list-group">${raceData.Results.map((result) =>
-        getDriverTemplate(result)
-      )}</ul>
+      <ul class="list-group">
+        ${raceData.Results.map((result) => getDriverTemplate(result)).join("")}
+      </ul>
     </div> 
     `;
 }


### PR DESCRIPTION
The comma issue was because we were using .map function without joining all strings with empty stri like this: `""` because by default it's with comma like this `","`

**Meaning:**
For example: 1, 2, 3, 4, 5 (default)
After my fix: 1 2 3 4 5 (when joining with empty string "")